### PR TITLE
updating query to run faster

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -36,7 +36,7 @@ app.config(['$stateProvider', '$urlRouterProvider',
   function($stateProvider, $urlRouterProvider){
 
     // TODO: external bootstrap with now testing build!
-    $urlRouterProvider.otherwise("/server/5.0.0/latest");
+    $urlRouterProvider.otherwise("/server/6.5.0/latest");
 
     $stateProvider
       .state('target', {

--- a/cbclient.js
+++ b/cbclient.js
@@ -56,7 +56,7 @@ module.exports = function(){
 
     queryVersions: function(bucket){
         var Q = "SELECT DISTINCT SPLIT(`build`,'-')[0] AS version"+
-                " FROM "+bucket+" ORDER BY version"
+                " FROM "+bucket+" where SPLIT(`build`,'-')[0] is not missing ORDER BY version"
         var qp = _query(bucket, strToQuery(Q))
           .then(function(data){
             versionsResponseCache[bucket] = data


### PR DESCRIPTION
this change to the query will allow it to use special index for faster queries. In the production system I will add the following indexes:

CREATE INDEX `distinctBuildsMobile` ON `mobile`((split(`build`, "-")[0]))
CREATE INDEX `distinctBuildsSDK` ON `sdk`((split(`build`, "-")[0]))
CREATE INDEX `distinctBuildsServer` ON `server`((split(`build`, "-")[0]))

CREATE INDEX `server_builds` ON `server`(`build`)
CREATE INDEX `sdk_builds` ON `sdk`(`build`)
CREATE INDEX `mobile_builds` ON `mobile`(`build`)

CREATE INDEX `server_builds_000` ON `server`(`build`) WHERE (`build` like "0.0.0%")
CREATE INDEX `server_builds_316` ON `server`(`build`) WHERE (`build` like "3.1.6%")
CREATE INDEX `server_builds_410` ON `server`(`build`) WHERE (`build` like "4.1.0%")
CREATE INDEX `server_builds_411` ON `server`(`build`) WHERE (`build` like "4.1.1%")
CREATE INDEX `server_builds_412` ON `server`(`build`) WHERE (`build` like "4.1.2%")
CREATE INDEX `server_builds_450` ON `server`(`build`) WHERE (`build` like "4.5.0%")
CREATE INDEX `server_builds_451` ON `server`(`build`) WHERE (`build` like "4.5.1%")
CREATE INDEX `server_builds_460` ON `server`(`build`) WHERE (`build` like "4.6.0%")
CREATE INDEX `server_builds_461` ON `server`(`build`) WHERE (`build` like "4.6.1%")
CREATE INDEX `server_builds_462` ON `server`(`build`) WHERE (`build` like "4.6.2%")
CREATE INDEX `server_builds_463` ON `server`(`build`) WHERE (`build` like "4.6.3%")
CREATE INDEX `server_builds_464` ON `server`(`build`) WHERE (`build` like "4.6.4%")
CREATE INDEX `server_builds_465` ON `server`(`build`) WHERE (`build` like "4.6.5%")
CREATE INDEX `server_builds_470` ON `server`(`build`) WHERE (`build` like "4.7.0%")
CREATE INDEX `server_builds_492` ON `server`(`build`) WHERE (`build` like "4.9.2%")
CREATE INDEX `server_builds_500` ON `server`(`build`) WHERE (`build` like "5.0.0%")
CREATE INDEX `server_builds_501` ON `server`(`build`) WHERE (`build` like "5.0.1%")
CREATE INDEX `server_builds_502` ON `server`(`build`) WHERE (`build` like "5.0.2%")
CREATE INDEX `server_builds_510` ON `server`(`build`) WHERE (`build` like "5.1.0%")
CREATE INDEX `server_builds_511` ON `server`(`build`) WHERE (`build` like "5.1.1%")
CREATE INDEX `server_builds_512` ON `server`(`build`) WHERE (`build` like "5.1.2%")
CREATE INDEX `server_builds_550` ON `server`(`build`) WHERE (`build` like "5.5.0%")
CREATE INDEX `server_builds_551` ON `server`(`build`) WHERE (`build` like "5.5.1%")
CREATE INDEX `server_builds_552` ON `server`(`build`) WHERE (`build` like "5.5.2%")
CREATE INDEX `server_builds_600` ON `server`(`build`) WHERE (`build` like "6.0.0%")
CREATE INDEX `server_builds_650` ON `server`(`build`) WHERE (`build` like "6.5.0%")

CREATE INDEX `mobile_builds_000` ON `mobile`(`build`) WHERE (`build` like "0.0.0%")
CREATE INDEX `mobile_builds_110` ON `mobile`(`build`) WHERE (`build` like "1.1.0%")
CREATE INDEX `mobile_builds_111` ON `mobile`(`build`) WHERE (`build` like "1.1.1%")
CREATE INDEX `mobile_builds_121` ON `mobile`(`build`) WHERE (`build` like "1.2.1%")
CREATE INDEX `mobile_builds_131` ON `mobile`(`build`) WHERE (`build` like "1.3.1%")
CREATE INDEX `mobile_builds_1311` ON `mobile`(`build`) WHERE (`build` like "1.3.1.1%")
CREATE INDEX `mobile_builds_1312` ON `mobile`(`build`) WHERE (`build` like "1.3.1.2%")
CREATE INDEX `mobile_builds_1313` ON `mobile`(`build`) WHERE (`build` like "1.3.1.3%")
CREATE INDEX `mobile_builds_1314` ON `mobile`(`build`) WHERE (`build` like "1.3.1.4%")
CREATE INDEX `mobile_builds_1315` ON `mobile`(`build`) WHERE (`build` like "1.3.1.5%")
CREATE INDEX `mobile_builds_140` ON `mobile`(`build`) WHERE (`build` like "1.4.0%")
CREATE INDEX `mobile_builds_1401` ON `mobile`(`build`) WHERE (`build` like "1.4.0.1%")
CREATE INDEX `mobile_builds_1402` ON `mobile`(`build`) WHERE (`build` like "1.4.0.2%")
CREATE INDEX `mobile_builds_141` ON `mobile`(`build`) WHERE (`build` like "1.4.1%")
CREATE INDEX `mobile_builds_1411` ON `mobile`(`build`) WHERE (`build` like "1.4.1.1%")
CREATE INDEX `mobile_builds_1412` ON `mobile`(`build`) WHERE (`build` like "1.4.1.2%")
CREATE INDEX `mobile_builds_1413` ON `mobile`(`build`) WHERE (`build` like "1.4.1.3%")
CREATE INDEX `mobile_builds_142` ON `mobile`(`build`) WHERE (`build` like "1.4.2%")
CREATE INDEX `mobile_builds_150` ON `mobile`(`build`) WHERE (`build` like "1.5.0%")
CREATE INDEX `mobile_builds_151` ON `mobile`(`build`) WHERE (`build` like "1.5.1%")
CREATE INDEX `mobile_builds_200` ON `mobile`(`build`) WHERE (`build` like "2.0.0%")
CREATE INDEX `mobile_builds_210` ON `mobile`(`build`) WHERE (`build` like "2.1.0%")
CREATE INDEX `mobile_builds_2100` ON `mobile`(`build`) WHERE (`build` like "2.1.0.0%")
CREATE INDEX `mobile_builds_250` ON `mobile`(`build`) WHERE (`build` like "2.5.0%")

These indexes should make greenboard run a lot faster. There will still be other areas of improvements but this should give us most bang for the buck.